### PR TITLE
Error out if a template value is missing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn yaml_to_gtmpl(input: Yaml) -> Result<gtmpl::Value, Box<dyn Error>> {
                 output.insert(key, yaml_to_gtmpl(value)?);
                 Ok(())
             })?;
-        Ok(Map(output))
+        Ok(Object(output))
     } else if input.as_i64().is_some() {
         Ok(Number(input.into_i64().unwrap().into()))
     } else if input.as_str().is_some() {


### PR DESCRIPTION
By using an `gtmpl::Value::Object` as the value for mappings in configs we get early errors 'for free' if the template tries to read a property that isn't defined (though the error format leaves something to be desired).